### PR TITLE
refactor(providers): use the same naming convention as strapi

### DIFF
--- a/packages/providers/provider-search-elasticsearch/package.json
+++ b/packages/providers/provider-search-elasticsearch/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@strapi-community/provider-search-elasticsearch",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/packages/providers/strapi-elastic-search-provider/package.json
+++ b/packages/providers/strapi-elastic-search-provider/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@strapi-community/strapi-plugin-search-elastic-search",
-  "version": "0.1.0",
-  "main": "index.js",
-  "license": "MIT"
-}


### PR DESCRIPTION
This PR refactors the provider naming convention/scheme to be the same as the one Strapi uses for their providers.